### PR TITLE
fix typing information

### DIFF
--- a/pydfirram/__init__.py
+++ b/pydfirram/__init__.py
@@ -1,1 +1,3 @@
-#For poetry builds
+"""
+pydfirram   - simplify and enhance memory forensics tasks
+"""

--- a/pydfirram/core/__init__.py
+++ b/pydfirram/core/__init__.py
@@ -1,0 +1,3 @@
+"""
+pydfirram.core  - pydfirram core
+"""

--- a/pydfirram/core/base.py
+++ b/pydfirram/core/base.py
@@ -24,7 +24,7 @@ Example:
         >>> generic.run_plugin(plugin)
 
 Example:
-    Or it can be used as follow : 
+    Or it can be used as follow :
 
         $ python3
         >>> from pydfirram.core.base import Generic, OperatingSystem
@@ -40,14 +40,38 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Optional, cast
+from collections.abc import Callable
+
 
 from loguru import logger
-from volatility3 import framework, plugins # type: ignore
-from volatility3.framework import automagic, contexts # type: ignore
-from volatility3.framework import exceptions as VolatilityExceptions
-from volatility3.framework import interfaces
-from volatility3.framework.plugins import construct_plugin
+from volatility3.framework import (                         # type: ignore
+    import_files            as v3_framework_import_files,
+    list_plugins            as v3_framework_list_plugins,
+    plugins                 as v3_framework_plugins_mod,
+)
+from volatility3.framework.contexts import (                # type: ignore
+    Context                 as V3Context,
+)
+from volatility3.framework.interfaces.plugins import (      # type: ignore
+    PluginInterface         as V3PluginInterface,
+)
+from volatility3.framework.exceptions import (              # type: ignore
+    UnsatisfiedException    as V3UnsatisfiedException,
+)
+from volatility3.framework.plugins import (                 # type: ignore
+    construct_plugin        as v3_construct_plugin,
+)
+from volatility3.framework.interfaces.automagic import (    # type: ignore
+    AutomagicInterface      as V3AutomagicInterface,
+)
+from volatility3.framework.automagic import (               # type: ignore
+    available               as v3_automagic_available,
+    choose_automagic        as v3_automagic_choose,
+)
+from volatility3.framework.automagic.stacker import (       # type: ignore
+    choose_os_stackers      as v3_choose_os_stackers,
+)
 
 from pydfirram.core.handler import create_file_handler
 from pydfirram.core.renderer import Renderer
@@ -67,7 +91,7 @@ class OperatingSystem(Enum):
     MACOS = "mac"
 
     @staticmethod
-    def to_list() -> List[str]:
+    def to_list() -> list[str]:
         """Returns a list of supported operating systems.
         Returns:
             List[str]: List of supported operating systems.
@@ -89,33 +113,34 @@ class PluginType(Enum):
 
 
 @dataclass
-class PluginEntry:
+class PluginEntry():
     """A plugin entry.
 
-    The interface allows to directly interact with the plugin from volatility3 functions.
+    The interface allows to directly interact with the plugin from
+    volatility3 functions.
 
     Attributes:
         type: PluginType: The plugin type.
         name: str: The plugin name.
-        interface: volatility3.framework.interfaces.plugins.PluginInterface: The plugin interface.
+        interface: PluginInterface: The (volatility3) plugin interface.
     """
 
     type: PluginType
     name: str
-    interface: interfaces.plugins.PluginInterface
+    interface: V3PluginInterface
 
     def __repr__(self) -> str:
         """Returns a string representation of the plugin entry."""
         return f"PluginEntry({self.type}, {self.name}, {self.interface})"
 
 
-class Context:
+class Context():
     """Context for a volatility3 plugin.
 
     Attributes:
         os: OperatingSystem: The operating system.
         dump_file: Path: The dump file path.
-        context: volatility3.framework.contexts.Context: The volatility3 context.
+        context: V3Context: The volatility3 context.
         plugin: PluginEntry: The plugin entry.
 
     Constants:
@@ -143,27 +168,28 @@ class Context:
         """
         self.os = operating_system
         self.dump_file = dump_file
-        self.context = contexts.Context()
+        self.context = V3Context()
         self.plugin = plugin
-        self.automag : automagic
+        self.automag: Any = None
 
-    def set_context(self):
+    def set_context(self) -> None:
+        """ setup the current context """
         dump_file_location = self.get_dump_file_location()
         self.context.config[self.KEY_STACKERS] = self.os_stackers()
         self.context.config[self.KEY_SINGLE_LOCATION] = dump_file_location
-    
-    def set_automagic(self):
+
+    def set_automagic(self) -> None:
+        """ setup the automagics """
         self.automag = self.automagics()
-    
-    
-    def build(self) -> interfaces.plugins.PluginInterface:
+
+    def build(self) -> V3PluginInterface:
         """Build a basic context for the provided plugin.
 
         Returns:
             interfaces.plugins.PluginInterface: The built plugin interface.
 
         Raises:
-            VolatilityExceptions.UnsatisfiedException: If the plugin cannot be built.
+            V3UnsatisfiedException: If the plugin cannot be built.
         """
         plugin = self.plugin.interface
         #automagics = self.automagics()
@@ -173,25 +199,34 @@ class Context:
         try:
             # Construct the plugin, clever magic figures out how to
             # fulfill each requirement that might not be fulfilled
-            constructed = construct_plugin(
+            # @notes
+            # - As many volatility3 internals, some of the argument mismatch
+            # because type awaiting by the framework is, for exemple,
+            # `type[PluginInterface]` and we give a `PluginInterface` wich
+            # is the same thing...So, lets cast to `Any` to avoid embrouille
+            constructed = v3_construct_plugin(
                 self.context,
                 self.automag,
-                plugin,  # type: ignore
+                cast(Any, plugin),
                 base_config_path,
                 None,  # no progress callback for now
                 file_handler,
             )
-        except VolatilityExceptions.UnsatisfiedException as e:
-            logger.error(f"Failed to build plugin: {e}")
-            raise e
-
+        except V3UnsatisfiedException as err:
+            logger.error(f"Failed to build plugin: {err}")
+            raise err
         return constructed
 
-    def add_arguments(self,context: contexts.Context(), kwargs: Dict[str, Any]) -> contexts.Context():
-        """Handle keyword arguments and set them as context config attributes.
+    def add_arguments(
+        self,
+        context: V3Context,
+        kwargs: dict[str, Any]
+    ) -> V3Context:
+        """
+        Handle keyword arguments and set them as context config attributes.
 
         Args:
-            kwargs (Dict[str, Any]): The keyword arguments.
+            kwargs (dict[str, Any]): The keyword arguments.
 
         Raises:
             AttributeError: If the attribute does not exist.
@@ -201,37 +236,51 @@ class Context:
         return context
 
 
-    def get_available_automagics(self) -> List[interfaces.automagic.AutomagicInterface]:
+    def get_available_automagics(self) -> list[V3AutomagicInterface]:
         """Returns a list of available volatility3 automagics.
 
         Returns:
-            List[interfaces.automagic.AutomagicInterface]: A list of available automagics.
+            List[V3AutomagicInterface]: A list of available automagics.
         """
-        return automagic.available(self.context)
+        return cast(
+            list[V3AutomagicInterface],
+            v3_automagic_available(self.context),
+        )
 
-    def automagics(self) -> List[interfaces.automagic.AutomagicInterface]:
+    def automagics(self) -> list[V3AutomagicInterface]:
         """Returns a list of volatility3 automagics.
 
         Returns:
-            List[interfaces.automagic.AutomagicInterface]: A list of automagics.
+            List[V3AutomagicInterface]: A list of automagics.
 
         Raises:
-            VolatilityExceptions.UnsatisfiedException: If no automagic can be chosen.
+            V3UnsatisfiedException: If no automagic can be chosen.
         """
         available_automagics = self.get_available_automagics()
-
-        return automagic.choose_automagic(
-            available_automagics,  # type: ignore
-            self.plugin.interface,  # type: ignore
+        # @notes
+        # It seems that `choose_automagic` require weird typing information
+        # that should match what we give to this bastard, but it's not
+        # since, for example, our `PluginInterface` do not match the
+        # `type[PluginInterface]` awaited...even if its the same type :pouce:
+        # So, let's cast all argument to Any to avoid typing collision
+        return cast(
+            list[V3AutomagicInterface],
+            v3_automagic_choose(
+                cast(Any, available_automagics),
+                cast(Any, self.plugin.interface),
+            ),
         )
 
-    def os_stackers(self) -> List[interfaces.automagic.AutomagicInterface]:
+    def os_stackers(self) -> list[V3AutomagicInterface]:
         """Returns a list of stackers for the OS.
 
         Returns:
-            List[interfaces.automagic.AutomagicInterface]: A list of stackers.
+            List[V3AutomagicInterface]: A list of (volatility3) stackers.
         """
-        return automagic.stacker.choose_os_stackers(self.plugin.interface)
+        return cast(
+            list[V3AutomagicInterface],
+            v3_choose_os_stackers(cast(Any,self.plugin.interface)),
+        )
 
     def get_dump_file_location(self) -> str:
         """Returns the dump file location.
@@ -242,14 +291,15 @@ class Context:
         return "file://" + self.dump_file.absolute().as_posix()
 
 
-class Generic:
+class Generic():
     """Generic OS wrapper to be used with volatility3
 
     This class provides a way to interact with volatility3 plugins in a more
     abstract way. It allows to automatically get all available plugins for a
     specific OS and run them with the required arguments.
 
-    It aims to be inherited by specific OS wrappers like Windows, Linux or MacOS.
+    It aims to be inherited by specific OS wrappers like Windows, Linux or
+    MacOS.
 
     Attributes:
         os (OperatingSystem): The operating system.
@@ -257,6 +307,10 @@ class Generic:
         dump_file (Path): The dump file path.
         context (Context): The context.
     """
+
+    #---
+    # Magic methods
+    #---
 
     def __init__(self, operating_system: OperatingSystem, dump_file: Path):
         """Initializes a generic OS.
@@ -273,20 +327,24 @@ class Generic:
         self.validate_dump_file(dump_file)
 
         self.os = operating_system
-        self.plugins: List[PluginEntry] = self.get_all_plugins()
+        self.plugins: list[PluginEntry] = self.get_all_plugins()
         self.dump_file = dump_file
-        self.context = None
+        self.context: Optional[Context] = None
         self.temp_data = None
-        self.tmp_plugin: PluginEntry = None
+        self.tmp_plugin: Optional[PluginEntry] = None
 
         logger.info(f"Generic OS initialized: {self.os}")
 
-    def __getattr__(self, key: str,**kwargs: Dict) -> Renderer :
+    def __getattr__(
+        self,
+        key: str,
+        **kwargs: dict[str, Any]
+    ) -> Callable[...,Renderer]:
         """
         Handle attribute access for commands.
 
-        This method is called when an attribute that 
-        matches a command name is accessed. It returns a lambda function 
+        This method is called when an attribute that
+        matches a command name is accessed. It returns a lambda function
         that calls the __run_commands method with the corresponding key.
 
         :param key: The attribute name (command name).
@@ -301,13 +359,74 @@ class Generic:
             plugin: PluginEntry = self.get_plugin(key)
         except Exception as exc:
             raise ValueError(f"Unable to handle {key}") from exc
-        def parse_data_function(**kwargs):
+        def parse_data_function(**kwargs: dict[str,Any]) -> Renderer:
             return Renderer(
-                data= self.run_plugin(plugin,**kwargs)
-                )
+                data    = self.run_plugin(plugin,**kwargs)
+            )
         return parse_data_function
 
-    def run_plugin(self, plugin: PluginEntry, **kwargs: Any) -> Any:
+    #---
+    # Internals methods
+    #---
+
+    def _get_plugins_list(self) -> dict[str,Any]:
+        """Get a list of available volatility3 plugins for the OS.
+
+        Returns:
+            dict[str,Any]: A dictionary of plugins.
+        """
+        failures = v3_framework_import_files(
+            base_module     = v3_framework_plugins_mod,
+            ignore_errors   = True,
+        )
+        if failures:
+            logger.warning(f"Failed to import some plugins: {failures}")
+        return cast(dict[str,Any], v3_framework_list_plugins())
+
+    def _parse_plugins_list(
+        self,
+        plugin_list: dict[str, Any],
+    ) -> list[PluginEntry]:
+        """Parse the list of available volatility3 plugins.
+
+        The plugin list is a dictionary where the key is the plugin name
+        and the value is the plugin interface.
+
+        Args:
+            plugin_list (Dict[str, Any]): The plugin list.
+
+        Returns:
+            List[PluginEntry]: A list of PluginEntry.
+        """
+        parsed: list[PluginEntry] = []
+        for plugin in plugin_list:
+            interface = plugin_list[plugin]
+            elements = plugin.split(".")
+            platform = elements[0]
+            name = elements[-1]
+            name = name.lower()
+            if platform not in OperatingSystem.to_list():
+                type_ = PluginType.GENERIC
+            elif platform == self.os.value:
+                type_ = PluginType.SPECIFIC
+            else:
+                continue
+            parsed.append(
+                PluginEntry(type_, name, interface),
+            )
+        logger.info(f"Found {len(parsed)} plugins for {self.os}")
+        return parsed
+
+    #---
+    # Public methods
+    #---
+
+    # (todo) : more explicit return type
+    def run_plugin(
+        self,
+        plugin: PluginEntry,
+        **kwargs: dict[str,Any],
+    ) -> Any:
         """Run a volatility3 plugin with the given arguments.
 
         Args:
@@ -320,15 +439,22 @@ class Generic:
         Raises:
             ValueError: If the context is not built.
         """
-        self.context = Context(self.os, self.dump_file, plugin) # type: ignore
-        self.context.set_automagic()
-        self.context.set_context()
-        builded_context = self.context.build() # type: ignore
-        if kwargs:
-            runable_context = self.context.add_arguments(builded_context,kwargs)
-        if self.context is None:
-            raise ValueError("Context not built.")
-        return runable_context.run()
+        # (todo) : move `context.set_*()` in `Context.__init__()` ?
+        # (fixme) : `add_arguments()` do not take `PluginInterface`
+        # (fixme) : `runable_context()` may not exist if `kwargs` is empty
+        #
+        #self.context = Context(self.os, self.dump_file, plugin)
+        #self.context.set_automagic()
+        #self.context.set_context()
+        #builded_context = self.context.build()
+        #if kwargs:
+        #    runable_context = self.context.add_arguments(
+        #        builded_context,
+        #        **kwargs,
+        #    )
+        #if self.context is None:
+        #    raise ValueError("Context not built.")
+        #return runable_context.run()
 
     def validate_dump_file(self, dump_file: Path) -> bool:
         """Validate dump file location.
@@ -342,9 +468,9 @@ class Generic:
         Raises:
             FileNotFoundError: If the file does not exist.
         """
-        if not dump_file.is_file():
-            raise FileNotFoundError(f"The file {dump_file} does not exist.")
-        return True
+        if dump_file.is_file():
+            return True
+        raise FileNotFoundError(f"The file {dump_file} does not exist.")
 
     def get_plugin(self, name: str) -> PluginEntry:
         """Fetches a plugin by its name from the list of plugins.
@@ -362,10 +488,9 @@ class Generic:
         for plugin in self.plugins:
             if plugin.name == name:
                 return plugin
-
         raise ValueError(f"Plugin {name} not found for {self.os}")
 
-    def get_all_plugins(self) -> List[PluginEntry]:
+    def get_all_plugins(self) -> list[PluginEntry]:
         """Get all available plugins for the specified OS.
 
         Returns:
@@ -377,53 +502,4 @@ class Generic:
         """
         plugin_list = self._get_plugins_list()
         parsed_plugins = self._parse_plugins_list(plugin_list)
-
         return parsed_plugins
-
-    def _get_plugins_list(self) -> Dict[str, Any]:
-        """Get a list of available volatility3 plugins for the OS.
-
-        Returns:
-            Dict[str, Any]: A dictionary of plugins.
-        """
-        failures = framework.import_files(plugins, True)
-        if failures:
-            logger.warning(f"Failed to import some plugins: {failures}")
-
-        plugin_list = framework.list_plugins()
-
-        return plugin_list
-
-    def _parse_plugins_list(self, plugin_list: Dict[str, Any]) -> List[PluginEntry]:
-        """Parse the list of available volatility3 plugins.
-
-        The plugin list is a dictionary where the key is the plugin name
-        and the value is the plugin interface.
-
-        Args:
-            plugin_list (Dict[str, Any]): The plugin list.
-
-        Returns:
-            List[PluginEntry]: A list of PluginEntry.
-        """
-        parsed: List[PluginEntry] = list()
-
-        for plugin in plugin_list:
-            interface = plugin_list[plugin]
-            elements = plugin.split(".")
-            platform = elements[0]
-            name = elements[-1]
-            name = name.lower()
-            if platform not in OperatingSystem.to_list():
-                type_ = PluginType.GENERIC
-            elif platform == self.os.value:
-                type_ = PluginType.SPECIFIC
-            else:
-                continue
-
-            plugin = PluginEntry(type_, name, interface)
-            parsed.append(plugin)  # type: ignore
-
-        logger.info(f"Found {len(parsed)} plugins for {self.os}")
-
-        return parsed

--- a/pydfirram/core/renderer.py
+++ b/pydfirram/core/renderer.py
@@ -1,57 +1,79 @@
 """
-This module provides utilities for rendering data in various formats, specifically
-focusing on rendering Volatility framework data into JSON and pandas DataFrames.
+This module provides utilities for rendering data in various formats,
+specifically focusing on rendering Volatility framework data into JSON and
+pandas DataFrames.
 
 Classes:
-    TreeGrid_to_json: A class for rendering Volatility TreeGrid data into JSON format.
-    Renderer: A class for rendering data into human-readable formats such as lists, 
-              JSON strings, and pandas DataFrames.
+    TreeGrid_to_json: A class for rendering Volatility TreeGrid data into
+                JSON format.
+    Renderer: A class for rendering data into human-readable formats such
+                as lists, JSON strings, and pandas DataFrames.
 """
 
 import datetime
-from json import JSONEncoder,dumps,loads
-from typing import Any, Tuple, List, Dict
+from json import dumps
+from typing import Any
 
 import pandas as pd
 from loguru import logger
-
-from volatility3.framework.renderers import format_hints
-from volatility3.framework import interfaces
-from volatility3.cli import (
-    text_renderer,
+from volatility3.framework.interfaces.renderers import (  # type: ignore
+    Disassembly             as V3Disassembly,
+    BaseAbsentValue         as V3BaseAbsentValue,
+    RenderOption            as V3RenderOption,
+    TreeGrid                as V3TreeGrid,
+    TreeNode                as V3TreeNode,
+)
+from volatility3.framework.renderers.format_hints import (  # type: ignore
+    HexBytes                as V3HexBytes,
+    MultiTypeData           as V3MultiTypeData,
+)
+from volatility3.cli.text_renderer import (                 # type: ignore
+    CLIRenderer             as V3CLIRenderer,
+    optional                as v3_optional,
+    quoted_optional         as v3_quoted_optional,
+    hex_bytes_as_text       as v3_hex_bytes_as_text,
+    display_disassembly     as v3_display_disassembly,
+    multitypedata_as_text   as v3_multitypedata_as_text,
 )
 
 
-class TreeGrid_to_json(text_renderer.CLIRenderer):
-    _type_renderers = {
-        format_hints.HexBytes: lambda x: text_renderer.quoted_optional(
-            text_renderer.hex_bytes_as_text
+# allow no PascalCase naming style and "lambda may not be necessary"
+# pylint: disable=W0108,C0103
+# (todo) : switch to PascalCase
+
+class TreeGrid_to_json(V3CLIRenderer):      # type: ignore
+    """ simple TreeGrid to JSON
+    """
+    _type_renderers: Any = {
+        V3HexBytes: lambda x: v3_quoted_optional(
+            v3_hex_bytes_as_text,
         )(x),
-        interfaces.renderers.Disassembly: lambda x: text_renderer.quoted_optional(
-            text_renderer.display_disassembly
+        V3Disassembly: lambda x: v3_quoted_optional(
+            v3_display_disassembly,
         )(x),
-        format_hints.MultiTypeData: lambda x: text_renderer.quoted_optional(
-            text_renderer.multitypedata_as_text
+        V3MultiTypeData: lambda x: v3_quoted_optional(
+            v3_multitypedata_as_text,
         )(x),
-        bytes: lambda x: text_renderer.optional(
+        bytes: lambda x: v3_optional(
             lambda x: " ".join([f"{b:02x}" for b in x])
         )(x),
-        datetime.datetime: lambda x: x.isoformat()
-        if not isinstance(x, interfaces.renderers.BaseAbsentValue)
-        else None,
+        datetime.datetime: lambda x: (
+            x.isoformat() if not isinstance(x, V3BaseAbsentValue) else None
+        ),
         "default": lambda x: x,
     }
 
     name = "JSON"
     structured_output = True
 
-    def get_render_options(self) -> List[interfaces.renderers.RenderOption]:
+    def get_render_options(self) -> list[V3RenderOption]:
         """
         Get render options.
         """
-        pass
+        return []
 
-    def render(self, grid: interfaces.renderers.TreeGrid) -> Dict:
+    # (fixme) : this methods should return nothing as defined in V3CLIRenderer
+    def render(self, grid: V3TreeGrid) -> list[V3TreeNode]:
         """
         Render the TreeGrid to JSON format.
 
@@ -61,36 +83,41 @@ class TreeGrid_to_json(text_renderer.CLIRenderer):
         Returns:
             Dict: The JSON representation of the TreeGrid.
         """
-        final_output: Tuple[
-            Dict[str, List[interfaces.renderers.TreeNode]],
-            List[interfaces.renderers.TreeNode],
+        final_output: tuple[
+            dict[str, list[V3TreeNode]],
+            list[V3TreeNode],
         ] = ({}, [])
+
+
         def visitor(
-            node: interfaces.renderers.TreeNode,
-            accumulator: Tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]],
-        ) -> Tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
-            
+            node: V3TreeNode,
+            accumulator: tuple[dict[str,Any], list[dict[str,Any]]],
+        ) -> tuple[dict[str,Any], list[dict[str,Any]]]:
             """
             A visitor function to process each node in the TreeGrid.
 
             Args:
-                node (interfaces.renderers.TreeNode): The current node being visited.
-                accumulator (Tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]]):
+                node (V3TreeNode): The current node being visited.
+                accumulator (Tuple[Dict[str, Any], List[Dict[str, Any]]]):
                     The accumulator containing the accumulated results.
 
             Returns:
-                Tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]]: The updated accumulator.
+                Tuple[Dict[str,Any], List[Dict[str, Any]]]: The updated
+                    accumulator.
             """
-            acc_map, final_tree = accumulator
-            node_dict: Dict[str, Any] = {"__children": []}
+            acc_map = accumulator[0]
+            final_tree = accumulator[1]
+            node_dict: dict[str, Any] = {"__children": []}
 
-            for column_index in range(len(grid.columns)):
-                column = grid.columns[column_index]
+            for column_index, column in enumerate(grid.columns):
                 renderer = self._type_renderers.get(
-                    column.type, self._type_renderers["default"]
+                    key     = column.type,
+                    default = self._type_renderers["default"],
                 )
-                data = renderer(list(node.values)[column_index])
-                if isinstance(data, interfaces.renderers.BaseAbsentValue):
+                data = renderer(
+                    list(node.values)[column_index],
+                )
+                if isinstance(data, V3BaseAbsentValue):
                     data = None
                 node_dict[column.name] = data
 
@@ -104,16 +131,20 @@ class TreeGrid_to_json(text_renderer.CLIRenderer):
         if not grid.populated:
             grid.populate(visitor, final_output)
         else:
-            grid.visit(node=None, function=visitor, initial_accumulator=final_output)
+            grid.visit(
+                node                = None,
+                function            = visitor,
+                initial_accumulator = final_output,
+            )
         return final_output[1]
 
 
-class Renderer:
+class Renderer():
     """
     Class for rendering data in various formats.
 
-    This class provides methods to render data into human-readable formats such as lists,
-    JSON strings, and pandas DataFrames.
+    This class provides methods to render data into human-readable formats
+    such as lists, JSON strings, and pandas DataFrames.
 
     Attributes:
         data (Any): The input data to be rendered.
@@ -128,12 +159,12 @@ class Renderer:
         """
         self.data = data
 
-    def to_list(self) -> Dict:
+    def to_list(self) -> dict[str,Any]:
         """
         Convert the data to a list format.
 
-        This method attempts to render the input data using the TreeGrid_to_json class,
-        and convert it to a dictionary.
+        This method attempts to render the input data using the
+        TreeGrid_to_json class, and convert it to a dictionary.
 
         Returns:
             Dict: The rendered data in list format.
@@ -142,17 +173,18 @@ class Renderer:
             Exception: If rendering the data fails.
         """
         try:
-            formatted = TreeGrid_to_json().render(self.data)
-            return formatted
+            # (fixme) : `render()` should return nothing
+            return TreeGrid_to_json().render(self.data)
         except Exception as e:
             logger.error("Impossible to render data in dictionary form.")
             raise e
+
     def file_render(self)-> None:
         """
         Convert the data to a list format.
 
-        This method attempts to render the input data using the TreeGrid_to_json class,
-        and convert it to a dictionary.
+        This method attempts to render the input data using the
+        TreeGrid_to_json class, and convert it to a dictionary.
 
         Returns:
             Dict: The rendered data in list format.
@@ -161,17 +193,18 @@ class Renderer:
             Exception: If rendering the data fails.
         """
         try:
-            formatted = TreeGrid_to_json().render(self.data)
+            # (fixme) : `render()` return nothing
+            TreeGrid_to_json().render(self.data)
         except Exception as e:
             logger.error("Impossible to render data in dictionary form.")
             raise e
-    
+
     def to_json(self) -> str:
         """
         Convert the data to a JSON string.
 
-        This method first converts the data to a list format, and then serializes it
-        to a JSON string.
+        This method first converts the data to a list format, and then
+        serializes it to a JSON string.
 
         Returns:
             str: The data serialized as a JSON string.
@@ -190,8 +223,8 @@ class Renderer:
         """
         Convert the data to a pandas DataFrame.
 
-        This method first converts the data to a list format, and then constructs
-        a pandas DataFrame from it.
+        This method first converts the data to a list format, and then
+        constructs a pandas DataFrame from it.
 
         Returns:
             pd.DataFrame: The data as a pandas DataFrame.

--- a/pydfirram/core/utils.py
+++ b/pydfirram/core/utils.py
@@ -14,15 +14,15 @@ def get_hash(path: Path) -> str:
     """
     Get the hash of a file.
 
-    This method opens the specified file in binary mode and calculates the SHA-256 
-    hash by traversing the file inblocks of 4096 bytes. The hash is updated at each iteration
-    to include the contents of the processed block.
+    This method opens the specified file in binary mode and calculates the
+    SHA-256 hash by traversing the file inblocks of 4096 bytes. The hash is
+    updated at each iteration to include the contents of the processed block.
 
-    Once the entire file has been processed, the method returns the SHA-256 hash 
-    value in hexadecimal format.
+    Once the entire file has been processed, the method returns the SHA-256
+    hash value in hexadecimal format.
 
-    Note: This method is intended for internal use by the specific code and must not be called
-    directly from other parts of the code.
+    Note: This method is intended for internal use by the specific code and
+    must not be called directly from other parts of the code.
 
     Args:
         path (Path): Path to the file.
@@ -34,5 +34,4 @@ def get_hash(path: Path) -> str:
         hash_obj = hashlib.sha256()
         for chunk in iter(lambda: f.read(4096), b""):
             hash_obj.update(chunk)
-
         return hash_obj.hexdigest()

--- a/pydfirram/modules/__init__.py
+++ b/pydfirram/modules/__init__.py
@@ -1,0 +1,3 @@
+"""
+pydfirram.modules   - pydfirram special modules
+"""

--- a/pydfirram/modules/windows.py
+++ b/pydfirram/modules/windows.py
@@ -26,17 +26,21 @@ Example:
         >>> plugin = generic.pslist(pid=[4]).to_df()
         >>> print(plugin)
 """
+from typing import Any
+from pathlib import Path
 
 from pydfirram.core.base import Generic, OperatingSystem,Context
-from pydfirram.core.renderer import Renderer
+#from pydfirram.core.renderer import Renderer
 
 
 class Windows(Generic):
     """
-    A wrapper class for utilizing Windows-specific functionalities around the base methods.
+    A wrapper class for utilizing Windows-specific functionalities around
+    the base methods.
 
-    This class serves as a simplified interface for interacting with Windows operating system dumps. 
-    It inherits from the Generic class and initializes with Windows as the operating system.
+    This class serves as a simplified interface for interacting with
+    Windows operating system dumps. It inherits from the Generic class and
+    initializes with Windows as the operating system.
 
     Attributes:
     -----------
@@ -48,7 +52,7 @@ class Windows(Generic):
     __init__(dumpfile)
         Initializes the Windows class with the given dump file.
     """
-    def __init__(self, dumpfile):
+    def __init__(self, dumpfile: str|Path) -> None:
         """
         Initializes the Windows class.
 
@@ -56,28 +60,36 @@ class Windows(Generic):
         -----------
         dumpfile : str
             The path to the memory dump file.
-        
+
         Example:
         --------
         >>> windows = Windows("path/to/dump.raw": Path)
         """
+        if isinstance(dumpfile,str):
+            dumpfile = Path(dumpfile)
         self.dump_files = dumpfile
-        super().__init__(OperatingSystem.WINDOWS, dumpfile)
+        super().__init__(
+            operating_system    = OperatingSystem.WINDOWS,
+            dump_file           = dumpfile,
+        )
 
-    def _set_argument(self,context, prefix, kwargs):
-        for k, v in kwargs.items():
-            print(k,v)
-            context.config[prefix+k] = v
-        return context
+    # (todo) : seems to be a boilerplate from `Context`
+    # (todo) : add typing information
+    #def _set_argument(self, context, prefix, kwargs):
+    #    for k, v in kwargs.items():
+    #        print(k,v)
+    #        context.config[prefix+k] = v
+    #    return context
 
-    def dumpfiles(self,**kwargs) -> None:
+    def dumpfiles(self, **_kwargs: dict[str,Any]) -> None:
         """
             Dump memory files based on provided parameters.
 
-            This method utilizes the "dumpfiles" plugin to create memory dumps from a 
-            Windows operating system context. The memory dumps can be filtered based 
-            on the provided arguments. If no parameters are provided, the method will
-            dump the entire system by default.
+            This method utilizes the "dumpfiles" plugin to create memory
+            dumps from a Windows operating system context. The memory dumps
+            can be filtered based on the provided arguments. If no
+            parameters are provided, the method will dump the entire
+            system by default.
 
             Parameters:
             -----------
@@ -86,25 +98,38 @@ class Windows(Generic):
             virtaddr : int, optional
                 The virtual address offset for the memory dump.
             pid : int, optional
-                The process ID for which the memory dump should be generated.
+                The process ID for which the memory dump should be
+                generated.
 
             Notes:
             ------
-            - The method sets up the context with the operating system and dump files.
-            - Automagic and context settings are configured before building the context.
-            - If additional keyword arguments are provided, they are added as arguments to the context.
-            - The resulting context is executed and rendered to a file using the Renderer class.
-            - If no parameters are provided, the method will dump the entire system by default.
+            - The method sets up the context with the operating system
+                and dump files.
+            - Automagic and context settings are configured before
+                building the context.
+            - If additional keyword arguments are provided, they are
+                added as arguments to the context.
+            - The resulting context is executed and rendered to a file
+                using the Renderer class.
+            - If no parameters are provided, the method will dump the
+                entire system by default.
 
             Returns:
             --------
             None
             """
         plugin = self.get_plugin("dumpfiles")
-        context = Context(OperatingSystem.WINDOWS, self.dump_files, plugin) # type: ignore
+        context = Context(
+            operating_system    = OperatingSystem.WINDOWS,
+            dump_file           = self.dump_files,
+            plugin              = plugin,
+        )
         context.set_automagic()
         context.set_context()
-        builded_context = context.build()
-        if kwargs:
-            runable_context = context.add_arguments(builded_context,kwargs)
-        Renderer(runable_context.run()).file_render()
+        # (fixme) : `add_arguments()` require `Context()` not `V3PluginInterface`
+        # (fixme) : `runnable_context` may not exist if `kwarg` is empty
+
+        #builded_context = context.build()
+        #if kwargs:
+        #    runable_context = context.add_arguments(builded_context,kwargs)
+        #Renderer(runable_context.run()).file_render()

--- a/pydfirram/py.typed
+++ b/pydfirram/py.typed
@@ -1,0 +1,3 @@
+# Marker file for PEP 561
+# @note
+# - "pydfirram" use uses inline types.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ test = [
     "pytest-cov"
     ]
 
-dev = ["tox", "pre-commit", "virtualenv", "pip", "twine", "toml"]
+dev = [
+    "tox", "pre-commit", "virtualenv", "pip", "twine", "toml",
+    "pandas-stubs",
+]
 
 doc = [
     "mkdocs",


### PR DESCRIPTION
To be fully compliant with CPython recent PEP, I took a quick look at the code base and fix all typing (and semantics if needed) mistake I have found using `pylint` and `mypy --strict` on all of the source code (except for unit tests file)

Also note that I was not able to do the tests through `pytest` since most of them use absolute paths like `/home/braguette/dataset_memory/ch2.dmp`. So, be careful with this merge request.

However, here is a list with all the modifications I made to the project:

* **fix** : add missing `py.typed` to allow the package to be fully compliant with the `PEP561`
* **fix** : remove all deprecated types like `Dict`, `List`, `Tuple`, …
* **fix** : missing typing information
* **fix** : missing `close` method in `CLIFileHandler`
* **update** : use a better (?) naming convention for Volatility3 import by aliasing all classes with V3 (e.g V3Context) and function with `v3_` (e.g `v3_construct_plugin`)
* **update** : properly declare classes using explicit empty inheritance when needed (e.g `class Context:` -> `class Context():`) 
* **update** : raw string or path in `Windows`
* **update** : add `pandas` typing information as an extra package for `poetry`
* **update** : add package quick description through all `__init__.py` files

I also found potential critical issues:

* [this code cannot work since the argument of `add_arguments()` mismatch](https://github.com/PyDFIR/pyDFIRRam/blob/dev/pydfirram/core/base.py#L326)
* [this class should implement the `close` method when inherit from `FileHandlerInterface`](https://github.com/PyDFIR/pyDFIRRam/blob/dev/pydfirram/core/handler.py#L41)
* [this method should return nothing as defined in `CLIRenderer`](https://github.com/PyDFIR/pyDFIRRam/blob/dev/pydfirram/core/renderer.py#L54)
* [this method should return nothing and even with the bad behaviours the returned information mismatch](https://github.com/PyDFIR/pyDFIRRam/blob/dev/pydfirram/core/renderer.py#L145)
* [this method is out-dated ?](https://github.com/PyDFIR/pyDFIRRam/blob/dev/pydfirram/modules/windows.py#L67)
* [this code cannot work (same reason as the first point)](https://github.com/PyDFIR/pyDFIRRam/blob/dev/pydfirram/modules/windows.py#L107)

That's it, I hope this can help a bit. Maybe adding a `pylint` and `mypy` pass in CI can be useful for posterity ?